### PR TITLE
Add stop callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # react-hotkey-hoc
-THIS IS MY HOTKEY HOC. THERE ARE MANY LIKE IT, BUT THIS ONE IS MINE. 
+THIS IS MY HOTKEY HOC. THERE ARE MANY LIKE IT, BUT THIS ONE IS MINE.
 
 ##Installation
 `npm i -S react-hotkey-hoc`
 
 ## What's it do
-This is a simple little higher-order component (HOC) for using mousetrap with react. 
+This is a simple little higher-order component (HOC) for using mousetrap with react.
 Mousetrap is a singleton, so unbinding things from it when components unmount is good.
 Writing unbinding logic in a lifecycle method is lame.
 Wrap your component with this & you get a prop to bind & then it'll automatically unbind when the component unmounts.
@@ -26,7 +26,7 @@ const statelessComponent = (props) {
   const onEventHandler = (event) => {
     return playWithPropsAndEvent(props, event);
   }
-  
+
   props.bindHotkey('enter', onEventHandler);
   return <Div onClick={onEventHandler}>Foo</Div>
 }
@@ -34,6 +34,49 @@ return withHotkey(statelessComponent);
 ```
 
 There is also an `unbindHotkey(keySequence)` in case you need to unbind it _before_ the component unmounts. This should generally be avoided, as state-based hotkeys might get confusing.
+
+## Advanced Usage: stopCallback middleware
+
+The HOC also exposes two props `addHotkeyStopMw` and `removeHotkeyStopMw`.
+You may use these functions to override Mousetrap's default
+[stopCallback](https://craig.is/killing/mice#api.stopCallback) with your
+own middleware function.
+
+The signature for a middleware function is:
+
+```javascript
+  (e, event, combo, next) => Boolean
+```
+
+This is useful if a component wants to disable hotkey events set by a
+higher component without needing to know which hotkey combinations have
+been registered.
+
+### Example of stopCallback Middleware
+
+Suppose you'd like your component to stop Mousetrap from processing all
+key events _except_ for `Escape` and `+` when your `input` component has
+focus. First you'd create a function like this:
+
+```javascript
+const stopHotKeyCallbackMw = (e, event, combo, next) => {
+  if (!(e.key === 'Escape' || e.key === '+')) {
+    return true;
+  }
+  return next();
+};
+```
+
+Next, you'd register your middleware using the `addHotkeyStopMw` function
+(provided by the HOC as a prop) when your component takes focus, and
+deregister it using the `removeHotkeyStopMw`.
+
+```javascript
+const onFocusInput = () => addHotkeyStopMw(stopHotKeyCallbackMw);
+const onBlurInput = () => removeHotkeyStopMw(stopHotKeyCallbackMw);
+```
+
+Easy as pie!
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,9 @@
 import React, {Component} from 'react';
 import Mousetrap from 'mousetrap';
+import {StopCbMwMgr} from './stopCbMwMgr';
+
+// initialize stopCallback Middleware Manager singleton:
+const stopCbMwMgr = new StopCbMwMgr();
 
 export default ComposedComponent => {
   return class WithHotkey extends Component {
@@ -13,17 +17,31 @@ export default ComposedComponent => {
       this.bindings.push(key);
     };
 
-    unbindHotkey = key => {
+    unbindHotkey = (key) => {
       Mousetrap.unbind(key);
     };
 
+    addHotkeyStopMw = (cb) => {
+      stopCbMwMgr.add(cb);
+    }
+
+    removeHotkeyStopMw = (cb) => {
+      stopCbMwMgr.remove(cb);
+    }
+
     componentWillUnmount() {
-      this.bindings.forEach(key => this.unbindHotkey(key));
+      this.bindings.forEach((key) => this.unbindHotkey(key));
     };
 
     render() {
       return (
-        <ComposedComponent bindHotkey={this.bindHotkey} unbindHotkey={this.unbindHotkey} {...this.props}/>
+        <ComposedComponent
+          bindHotkey={this.bindHotkey}
+          unbindHotkey={this.unbindHotkey}
+          addHotkeyStopMw={this.addHotkeyStopMw}
+          removeHotkeyStopMw={this.removeHotkeyStopMw}
+          {...this.props}
+        />
       );
     }
   }

--- a/src/stopCbMwMgr.js
+++ b/src/stopCbMwMgr.js
@@ -1,0 +1,40 @@
+import Mousetrap from 'mousetrap';
+
+export class StopCbMwMgr {
+  constructor() {
+    const defaultStopCb = Mousetrap.prototype.stopCallback;
+    const defaultMw = (e, element, combo, next) => {
+      if (!defaultStopCb(e, element, combo)) {
+        return next();
+      }
+      return true;
+    }
+    this.middleware = new Set();
+    this.add(defaultMw);
+  }
+
+  rebuildMiddware() {
+    let chain = (e, element, combo, next) => next(e, element, combo);
+    const use = (fn) => {
+      chain = ((stack) => (e, element, combo, next) => stack(
+        e, element, combo, () => fn.call(
+          this, e, element, combo, next.bind(this)))
+      )(chain);
+    }
+    this.middleware.forEach((fn) => use(fn));
+    const stopCallback = (e, element, combo) =>
+      chain(e, element, combo, () => false);
+    Mousetrap.prototype.stopCallback = stopCallback;
+  }
+
+  add(fn) {
+    this.middleware.add(fn);
+    this.rebuildMiddware();
+  }
+
+  remove(fn) {
+    this.middleware.delete(fn);
+    this.rebuildMiddware();
+  }
+
+}


### PR DESCRIPTION
Added two props `addHotkeyStopMw` and `removeHotkeyStopMw`.
You may use these functions to override Mousetrap's default
[stopCallback](https://craig.is/killing/mice#api.stopCallback) with your
own middleware function.

The signature for a middleware function is:

```javascript
  (e, event, combo, next) => Boolean
```

This is useful if a component wants to disable hotkey events set by a
higher component without needing to know which hotkey combinations have
been registered.

Also added documentation.